### PR TITLE
Fix issue #29 in The Cyclone

### DIFF
--- a/3-control-flow/15_the_cyclone_2.py
+++ b/3-control-flow/15_the_cyclone_2.py
@@ -5,10 +5,10 @@ height = 250
 credits = 10
 with_taller_person = False
 
-if height >= 137 and credits >= 10:
-  print("Enjoy the ride!")
-elif credits < 10:
+if credits < 10:
   print("You don't have enough credits to ride.")
+elif height >= 137 and credits >= 10:
+  print("Enjoy the ride!")
 elif height < 137:
   if height < 100 or not with_taller_person:
     print("You're not tall enough for this ride yet.")

--- a/3-control-flow/15_the_cyclone_2.py
+++ b/3-control-flow/15_the_cyclone_2.py
@@ -13,6 +13,6 @@ elif height < 137:
   if height < 100 or not with_taller_person:
     print("You're not tall enough for this ride yet.")
   elif height >= 100 and with_taller_person:
-    print("Enjoy the ride!")
+    print("Enjoy the ride, folks!")
 else:
   print("Invalid data.")

--- a/3-control-flow/15_the_cyclone_2.py
+++ b/3-control-flow/15_the_cyclone_2.py
@@ -7,12 +7,12 @@ with_taller_person = False
 
 if height >= 137 and credits >= 10:
   print("Enjoy the ride!")
+elif credits < 10:
+  print("You don't have enough credits to ride.")
 elif height < 137:
   if height < 100 or not with_taller_person:
     print("You're not tall enough for this ride yet.")
   elif height >= 100 and with_taller_person:
     print("Enjoy the ride!")
-elif credits < 10:
-  print("You don't have enough credits to ride.")
 else:
   print("Invalid data.")


### PR DESCRIPTION
Closes #29 

Reorder lines so that `credits` gets checked before `height`, to resolve https://github.com/codedex-io/python-101/issues/29 . Note that this does alter output in cases where credits and height are both too small, so if you specifically want babies with no money to be told "you're not tall enough" instead of "you don't have enough credits", then a different fix might be preferred.