### PR TITLE
Update solution #2 for Cyclone challenge

### DIFF
--- a/3-control-flow/15_the_cyclone_2.py
+++ b/3-control-flow/15_the_cyclone_2.py
@@ -5,14 +5,15 @@ height = 250
 credits = 10
 with_taller_person = False
 
-if height >= 137 and credits >= 10:
-  print("Enjoy the ride!")
-elif height < 137:
-  if height < 100 or not with_taller_person:
-    print("You're not tall enough for this ride yet.")
-  elif height >= 100 and with_taller_person:
-    print("Enjoy the ride!")
-elif credits < 10:
+if credits < 10:
   print("You don't have enough credits to ride.")
 else:
-  print("Invalid data.")
+  if height >= 137 and credits >= 10:
+    print("Enjoy the ride!")
+  elif height < 137:
+    if height < 100 or not with_taller_person:
+      print("You're not tall enough for this ride yet.")
+    elif height >= 100 and with_taller_person:
+      print("Enjoy the ride, folks!")
+  else:
+    print("Invalid data.")


### PR DESCRIPTION
Closes #29 

This was flagged by a user.

Fixes a buggy scenario where "Enjoy the ride" would print despite `credits` being less than 10. Some of the phrases in the `print()` statements were edited, as well.