### PR TITLE
fix: typo from scisssors to scissors

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -4,7 +4,7 @@
 
 - 🥠 Fortune Cookie
 - 🎲 Dice Rolling Simulator
-- 🫱 Rock Paper Scisssors
+- 🫱 Rock Paper Scissors
 - 🫱 Rock Paper Scissors Lizard Spark
 - 🤑 Who Wants to Be a Millionaire
 - ❓ Quiz Game

--- a/projects.md
+++ b/projects.md
@@ -4,7 +4,7 @@
 
 - 🥠 Fortune Cookie
 - 🎲 Dice Rolling Simulator
-- 🫱 Rock Paper Scisssors
+- 🫱 Rock Paper Scissors
 - 🫱 Rock Paper Scissors Lizard Spock
 - 🤑 Who Wants to Be a Millionaire
 - ❓ Quiz Game


### PR DESCRIPTION
## Fix: Typo in `projects.md`
- This PR fixes a typo found in `projects.md` for the word `scissors`.

## Changes:
- Fixes the spelling of `scisssors` to `scissors`.

## Related issue:
- This PR closes #63.