### PR TITLE
fix: game name word from spark to spock

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -5,7 +5,7 @@
 - 🥠 Fortune Cookie
 - 🎲 Dice Rolling Simulator
 - 🫱 Rock Paper Scisssors
-- 🫱 Rock Paper Scissors Lizard Spark
+- 🫱 Rock Paper Scissors Lizard Spock
 - 🤑 Who Wants to Be a Millionaire
 - ❓ Quiz Game
 - ⚔️ Text-Based Adventure


### PR DESCRIPTION
## Fix: Game name word from _spark_ to **spock**
- This PR fixes the word `spark` to `spock`. The wrong word was used in `projects.md`.

## Expected behavior:
- The original link to the [50 Terminal Projects](https://www.codedex.io/projects/50-terminal-project-ideas-using-python) that showcases this game has the correct spelling
<img width="536" alt="image" src="https://github.com/codedex-io/python-101/assets/140430987/f240faf6-914b-438f-bfa3-e1c2d7f48d38">

## Related issue:
- This PR closes #65.