### PR TITLE
Proposal of fix to typo in in 27_bucket_list.py

### DIFF
--- a/5-lists/27_bucket_list.py
+++ b/5-lists/27_bucket_list.py
@@ -7,7 +7,7 @@ things_to_do = [
    '🌏 Visit at least 10 countries in my lifetime.',
    '🚲 Try out mountain biking.',
    '🎸 Produce an original song.',
-   '🚀 Build a menaingful product for everyone.',
+   '🚀 Build a meaningful product for everyone.',
 ]
 
 for thing in things_to_do:


### PR DESCRIPTION
Hello team,

I would like to report a typo from this [file](https://github.com/codedex-io/python-101/blob/main/5-lists/27_bucket_list.py).

The string 'paragragh' should be replaced with 'paragraph'.

See attached picture for more context. 👇
![bucket-list-typo](https://github.com/codedex-io/python-101/assets/48260426/8c2addca-5618-4910-80a1-201c52a52779)
