### PR TITLE
Proposal of fix to typo in file 38_pokedex.py

### DIFF
--- a/7-classes-objects/38_pokedex.py
+++ b/7-classes-objects/38_pokedex.py
@@ -32,6 +32,6 @@ class Pokemon:
       print(self.name + ' hasn\'t been caught yet.')
 
 # Pokémon objects
-pikachu = Pokemon('Pikachu', ['Electric'], 'It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs.', 25, 'Kanto', True)
+pikachu = Pokemon('Pikachu', ['Electric'], 'It has small electric sacs on both its cheeks. If threatened, it loses electric charges from the sacs.', 25, 'Kanto', True)
 charizard = Pokemon('Charizard', ['Fire', 'Flying'], 'It spits fire that is hot enough to melt boulders. It may cause forest fires by blowing flames.', 36, 'Kanto', False)
 gyarados = Pokemon('Gyarados', ['Water', 'Flying'], 'It has an extremely aggressive nature. The HYPER BEAM it shoots from its mouth totally incinerates all targets.', 57, 'Kanto', False)


### PR DESCRIPTION
Hello team,

I would like to report a typo from this [file](https://github.com/codedex-io/python-101/blob/main/7-classes-objects/38_pokedex.py).

The string 'looses' should be replaced with 'loses'.

See attached picture for more context. 👇
![pokedex_typo](https://github.com/codedex-io/python-101/assets/48260426/fe4192df-2d4f-49a5-9195-5dc9a8b76d5c)
