### PR TITLE
fix: remove unused option-8

### DIFF
--- a/6-functions/29_fortune_cookie_1.py
+++ b/6-functions/29_fortune_cookie_1.py
@@ -33,8 +33,6 @@ def fortune():
     option = options[6]
   elif random_fortune == 7:
     option = options[7]
-  elif random_fortune == 8:
-    option = options[8]
   else:
     option = 'Error'
 


### PR DESCRIPTION
## Fix: Removed unused/unreachable option[8]
- This PR fixes an oversight with an extra option added to the logic in [29_fortune_cookie_1.py](https://github.com/codedex-io/python-101/blob/main/6-functions/29_fortune_cookie_1.py).
### Changes:
- Removed `option[8]` from the logic as this option will never be reachable since the range is `(0, 7)` which is made up of `8` indexes and the logic starts with `0` as the main `if` statement.

### Screenshot of change:
<img width="396" alt="image" src="https://github.com/codedex-io/python-101/assets/140430987/f524b1c0-a1a1-40c2-bbaa-edfaf720347b">

### Related issues:
- This PR closes #76.