### PR TITLE
Fix: Remove trailing space in file 17_enter_pin.py

### DIFF
--- a/4-loops/17_enter_pin.py
+++ b/4-loops/17_enter_pin.py
@@ -1,7 +1,7 @@
 # Enter PIN 🏦
 # Codédex
 
-print('=== BANK OF CODéDEX ===')  
+print('=== BANK OF CODéDEX ===')
 
 pin = int(input('Enter your PIN: '))
 


### PR DESCRIPTION
I would like to propose a solution to this [issue](https://github.com/codedex-io/python-101/issues/new).

There are some trailing space on line 4. Removing the trailing space would make the file look more professional.

