### PR TITLE
Fix Charizard's Pokédex number from 3 to 6 in both files

### DIFF
--- a/7-classes-objects/38_pokedex_1.py
+++ b/7-classes-objects/38_pokedex_1.py
@@ -31,7 +31,7 @@ class Pokemon:
 
 # Pokémon objects
 pikachu = Pokemon(25, 'Pikachu', ['Electric'], 'It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs.', True)
-charizard = Pokemon(3, 'Charizard', ['Fire', 'Flying'], 'It spits fire that is hot enough to melt boulders. It may cause forest fires by blowing flames.', False)
+charizard = Pokemon(6, 'Charizard', ['Fire', 'Flying'], 'It spits fire that is hot enough to melt boulders. It may cause forest fires by blowing flames.', False)
 gyarados = Pokemon(130, 'Gyarados', ['Water', 'Flying'], 'It has an extremely aggressive nature. The HYPER BEAM it shoots from its mouth totally incinerates all targets.', False)
 
 pikachu.speak()

--- a/7-classes-objects/38_pokedex_2.py
+++ b/7-classes-objects/38_pokedex_2.py
@@ -35,7 +35,7 @@ class Pokemon:
 
 # Pokémon objects
 pikachu = Pokemon(25, 'Pikachu', ['Electric'], 'It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs.', 25, 'Kanto', True)
-charizard = Pokemon(3, 'Charizard', ['Fire', 'Flying'], 'It spits fire that is hot enough to melt boulders. It may cause forest fires by blowing flames.', 36, 'Kanto', False)
+charizard = Pokemon(6, 'Charizard', ['Fire', 'Flying'], 'It spits fire that is hot enough to melt boulders. It may cause forest fires by blowing flames.', 36, 'Kanto', False)
 gyarados = Pokemon(130, 'Gyarados', ['Water', 'Flying'], 'It has an extremely aggressive nature. The HYPER BEAM it shoots from its mouth totally incinerates all targets.', 57, 'Kanto', False)
 
 pikachu.speak()


### PR DESCRIPTION
Noticed that Charizard's Pokédex number was set to 3 in both 38_pokedex_1.py and 38_pokedex_2.py, which is actually the entry for Venusaur. I’ve gone ahead and corrected it to 6, which is the proper number for Charizard. 😊