### PR TITLE
Fix: List in the solution differs from the instructions.

### DIFF
--- a/5-lists/24_inventory.py
+++ b/5-lists/24_inventory.py
@@ -1,7 +1,7 @@
 # Inventory 📦
 # Codédex
 
-airplane_toys = [ 898, 732, 543, 878 ]
+lego_parts = [8980, 7323, 5343, 82700, 92232, 1203, 7319, 8903, 2328, 1279, 679, 589]
 
-print(min(airplane_toys))
-print(max(airplane_toys))
+print(min(lego_parts))
+print(max(lego_parts))


### PR DESCRIPTION
I noticed that the instructions in section 24, 'Inventory,' mention a list named 'lego_parts,' but here on GitHub, the list used is 'airplane_toys.