### PR TITLE
fix: add missing print(vars())

### DIFF
--- a/7-classes-objects/35_bobs_burgers.py
+++ b/7-classes-objects/35_bobs_burgers.py
@@ -24,3 +24,7 @@ baekjeong.name = 'Baekjeong NYC'
 baekjeong.type = 'Korean BBQ'
 baekjeong.rating = 4.4
 baekjeong.delivery = False
+
+print(vars(bobs_burgers))
+print(vars(katz_deli))
+print(vars(baekjeong))


### PR DESCRIPTION
In class 35, "Bob's Burger," the instructions say to use print(vars()) to output each of the three restaurants, but the solution does not include the print(vars()) statements, so I included them.