### PR TITLE
fix: correct attributes name to match instructions

### DIFF
--- a/7-classes-objects/34_restaurants.py
+++ b/7-classes-objects/34_restaurants.py
@@ -3,6 +3,6 @@
 
 class Restaurant:
   name = ''
-  description = ''
+  category = ''
   rating = 0.0
-  deliver = True
+  delivery = True


### PR DESCRIPTION
I noticed that the names of the attributes in the sollution were different from the instructions given in class 34, Restaurants. Then, I corrected this to ensure consistency.