### PR TITLE
Update 32_stonks.py

### DIFF
--- a/6-functions/32_stonks.py
+++ b/6-functions/32_stonks.py
@@ -14,7 +14,7 @@ def max_price(a, b):
 
 def min_price(a, b):
   mn = price_at(a)
-  for i in range(a, b + 1):
+  for i in range(a + 1, b + 1):
     mn = min(mn, price_at(i))
   return mn
 


### PR DESCRIPTION
The code for `min_price` can be improved by removing redundant comparison.

```
def min_price(a, b):
  mn = price_at(a)
  for i in range(a, b + 1):
    mn = min(mn, price_at(i))
  return mn
```

`mn` is initialized with value of `price_at(a)` and that, however, means that the line where `mn` is updated becomes `mn = min(price_at(a), price_at(a))`, this is redundant and it's possible to skip it.