### PR TITLE
Fix currency input validation in 10_currency.py

### DIFF
--- a/2-variables/10_currency.py
+++ b/2-variables/10_currency.py
@@ -1,9 +1,9 @@
 # Currency 💵
 # Codédex
 
-pesos = int(input('What do you have left in pesos? '))
-soles = int(input('What do you have left in soles? '))
-reais = int(input('What do you have left in reais? '))
+pesos = float(input('What do you have left in pesos? '))
+soles = float(input('What do you have left in soles? '))
+reais = float(input('What do you have left in reais? '))
 
 total = pesos * 0.00025 + soles * 0.28 + reais * 0.21
 


### PR DESCRIPTION
## Summary
Fixed the currency converter to properly handle decimal values by changing `int(input())` to `float(input())` for all three currency inputs (pesos, soles, reais).

## Problem
The original code used `int(input())` which truncates decimal places, causing incorrect calculations when users input currency amounts with cents (e.g., 10.50 would become 10).

## Solution
- Changed all three `int(input())` calls to `float(input())` 
- Tested with decimal values to ensure correct calculation
- Verified the fix works properly with sample inputs

## Test Results
Tested with inputs: 100.50 pesos, 200.75 soles, 150.25 reais
Expected result: 87.787625
Actual result: 87.787625 ✅

Fixes #127