### PR TITLE
fix: change input type from int to float in currency converter

### DIFF
--- a/2-variables/10_currency.py
+++ b/2-variables/10_currency.py
@@ -1,9 +1,9 @@
 # Currency 💵
 # Codédex
 
-pesos = int(input('What do you have left in pesos? '))
-soles = int(input('What do you have left in soles? '))
-reais = int(input('What do you have left in reais? '))
+pesos = float(input('What do you have left in pesos? '))
+soles = float(input('What do you have left in soles? '))
+reais = float(input('What do you have left in reais? '))
 
 total = pesos * 0.00025 + soles * 0.28 + reais * 0.21
 


### PR DESCRIPTION
### What this PR does
- Changes input types from `int` to `float` for pesos, soles, and reais.
- Allows decimal values in the currency converter.

### Why
Previously, the code only accepted whole numbers. This caused incorrect behavior if the user entered decimals.

### Example
Input: 
- pesos = 100.5
- soles = 50.25
- reais = 30.75

Output: 
- total = 17.04875